### PR TITLE
fix: escape JSON parameters in PowerShell scripts

### DIFF
--- a/.github/workflows/azure-deploy.yml
+++ b/.github/workflows/azure-deploy.yml
@@ -171,12 +171,14 @@ jobs:
       - name: Deploy Bicep template
         id: deploy
         shell: pwsh
+        env:
+          SERVICE_BUS_QUEUES: ${{ inputs.service-bus-queues }}
         run: |
           Write-Host "Deploying to resource group '${{ inputs.resource-group }}'..."
           Write-Host "  appNamePrefix: ${{ inputs.app-name-prefix }}"
           Write-Host "  environment: ${{ inputs.environment }}"
           Write-Host "  location: ${{ inputs.location }}"
-          Write-Host "  serviceBusQueues: ${{ inputs.service-bus-queues }}"
+          Write-Host "  serviceBusQueues: $env:SERVICE_BUS_QUEUES"
 
           $deploymentName = "ppds-alm-${{ inputs.environment }}-$(Get-Date -Format 'yyyyMMddHHmmss')"
 
@@ -189,7 +191,7 @@ jobs:
             '--parameters', "appNamePrefix=${{ inputs.app-name-prefix }}"
             '--parameters', "environment=${{ inputs.environment }}"
             '--parameters', "location=${{ inputs.location }}"
-            '--parameters', "serviceBusQueues=${{ inputs.service-bus-queues }}"
+            '--parameters', "serviceBusQueues=$env:SERVICE_BUS_QUEUES"
             '--output', 'json'
           )
 


### PR DESCRIPTION
## Summary
- Fixes PowerShell parser error when JSON parameters contain quotes
- Passes `service-bus-queues` via environment variable instead of direct interpolation

## Root Cause
When `service-bus-queues` input like `[{"name": "account-updates"}]` was interpolated directly into PowerShell double-quoted strings, the embedded quotes broke parsing:

```
ParserError: Unexpected token 'name": "account-updates"}]"' in expression or statement.
```

## Fix
Use `env:` block to pass JSON safely:
```yaml
env:
  SERVICE_BUS_QUEUES: ${{ inputs.service-bus-queues }}
run: |
  '--parameters', "serviceBusQueues=$env:SERVICE_BUS_QUEUES"
```

## Test plan
- [ ] Re-run ppds-demo Azure deploy workflow after merging and updating v1 tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)